### PR TITLE
Fix error when TLS=on and InsecureSSL=off

### DIFF
--- a/sample.conf
+++ b/sample.conf
@@ -26,6 +26,11 @@ ChunkSize=10240
 
 ; A server definition. You can have multiple if you like that sort of thing.
 [server "pants"]
+
+; Address is used as ServerName tls.Config when TLS='on' and InsecureSSL='off',
+; hence it should match the server name on the server's certificate. This will
+; be the case for any sane server setup. If not you will see an x509-error
+; "certificate is valid for x but not y".
 Address=testserver.int
 Port=563
 

--- a/sample.conf
+++ b/sample.conf
@@ -26,12 +26,7 @@ ChunkSize=10240
 
 ; A server definition. You can have multiple if you like that sort of thing.
 [server "pants"]
-
-; Address is used as ServerName tls.Config when TLS='on' and InsecureSSL='off',
-; hence it should match the server name on the server's certificate. This will
-; be the case for any sane server setup. If not you will see an x509-error
-; "certificate is valid for x but not y".
-Address=testserver.int
+Address=us.newsprovider.com
 Port=563
 
 ; Leave password blank if you only need a username. Leave both blank if you
@@ -45,6 +40,9 @@ Password=topsecret
 Connections=8
 
 ; Encryption - 'on', 'off', whatever.
+; Address is used as ServerName tls.Config when TLS='on' and InsecureSSL='off'.
+; Hence you will get a "certificate is valid for x but not y"-error if the 
+; Address does not match the server name of the server's certificate.
 TLS=on
 
 ; Ignore SSL errors like self-signed certificates. This is a pretty bad idea.

--- a/simplenntp/simplenntp.go
+++ b/simplenntp/simplenntp.go
@@ -70,7 +70,8 @@ func Dial(address string, port int, useTLS bool, insecureSSL bool, tdchan chan *
 
 	if useTLS {
 		// Create and handshake a TLS connection
-		tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: insecureSSL})
+        // Use the server address as ServerName for certificate verifucation
+        tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: insecureSSL,ServerName: address})
 		err = tlsConn.Handshake()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
For me all versions of GoPostStuff (madcowfred, F4n4t, and ERR1R) gave errors if you specify ```TLS=on``` and ```InsecureSSL=off```: 

`tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config`

The problem seemed to be that no server name was available for ```crypto/tls``` to compare to the certificate of the server it connects to, as seen in the error.

My fix was to pass the ```Address=some.host.com``` from the config file as ```ServerName``` in the ```tls.Config``` object.